### PR TITLE
Rewinder refactor

### DIFF
--- a/librewinder/design_rewinder.py
+++ b/librewinder/design_rewinder.py
@@ -7,6 +7,21 @@ import warnings
 
 def design_rewinder(g_grad, GRT, T_rew, system, slew_ratio=0.7, grad_rew_method='gropt', M1_nulling=False):
 
+    """Design_rewinder for spiral trajectories.
+
+    Inputs:
+        g_grad: array [readout x 2] in units mT/m 
+        GRT: gradient raster time (s)
+        T_rew: time for rewind (s)
+        system: pulseq system object (containing max grad, slew, and other hardware limits)
+        slew_ratio: slew ratio to limit spiral rewinder
+        grad_rew_method: 'gropt', 'ext_trap_area', 'exact_time', 'm1_nayak'
+        M1_nulling: true or false (only available with 'gropt')
+    
+    Returns:
+        g_rewind_x g_rewind_y 
+    """
+
 
     # === design rewinder ===
     M0 = np.cumsum(g_grad, axis=0) * GRT * 1e3 # [mT.s/m] -> [mT.ms/m]

--- a/librewinder/design_rewinder.py
+++ b/librewinder/design_rewinder.py
@@ -1,11 +1,11 @@
 import numpy as np
 from libspiralutils import pts_to_waveform, design_rewinder_exact_time
 import copy
-from librewinder.rewinder_m1_nayak import spiral_rewinder_m1_nayak
+from .rewinder_m1_nayak import spiral_rewinder_m1_nayak
 import warnings
 
 
-def design_rewinder(g_grad, GRT, T_rew, system, slew_ratio=0.7, grad_rew_method='gropt', M1_nulling=False):
+def design_rewinder(g_grad, T_rew, system, slew_ratio=0.7, grad_rew_method='gropt', M1_nulling=False):
 
     """Design_rewinder for spiral trajectories.
 
@@ -21,7 +21,7 @@ def design_rewinder(g_grad, GRT, T_rew, system, slew_ratio=0.7, grad_rew_method=
     Returns:
         g_rewind_x g_rewind_y 
     """
-
+    GRT = system.grad_raster_time
 
     # === design rewinder ===
     M0 = np.cumsum(g_grad, axis=0) * GRT * 1e3 # [mT.s/m] -> [mT.ms/m]

--- a/librewinder/design_rewinder.py
+++ b/librewinder/design_rewinder.py
@@ -1,0 +1,100 @@
+import numpy as np
+from libspiralutils import pts_to_waveform, design_rewinder_exact_time
+import copy
+from librewinder.rewinder_m1_nayak import spiral_rewinder_m1_nayak
+import warnings
+
+
+def design_rewinder(g_grad, GRT, T_rew, system, slew_ratio=0.7, grad_rew_method='gropt', M1_nulling=False):
+
+
+    # === design rewinder ===
+    M0 = np.cumsum(g_grad, axis=0) * GRT * 1e3 # [mT.s/m] -> [mT.ms/m]
+    t = (np.arange(1, g_grad.shape[0]+1))*GRT*1e3 # [ms]
+    tt = (t*np.ones((2, 1))).T
+    M1 = np.cumsum(g_grad*tt, axis=0)*GRT*1e3 # [mT.ms^2/m]
+
+
+    grad_scale = 42.58e3 # from mT/m -> Hz/m
+    slew_scale = 42.58e6 # from T/m/s -> Hz/m/s
+
+    max_grad = system.max_grad / grad_scale
+    max_slew = system.max_slew / slew_scale
+
+    # Design rew with gropt
+    if grad_rew_method == 'gropt':
+        from gropt import get_min_TE_gfix
+
+        # Method 1: GrOpt, separate optimization
+        gropt_params = {}
+        gropt_params['mode'] = 'free'
+        gropt_params['gmax'] = max_grad*1e-3 # [mT/m] -> [T/m]
+        gropt_params['smax'] = max_slew * slew_ratio
+        gropt_params['dt']   = GRT
+
+        gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M0[-1,0], 1.0e-5]]
+        
+        if M1_nulling:
+            gropt_params['moment_params'].append([0, 1, 0, -1, -1, -M1[-1,0]+M0[-1,0]*(t[-1]+GRT*1e3), 1.0e-5])
+
+        gropt_params['gfix']  = np.array([g_grad[-1, 0]*1e-3, -99999, 0])
+
+        g_rewind_x, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
+        g_rewind_x = g_rewind_x.T[:,0]*1e3
+
+        gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M0[-1,1], 1.0e-5]]
+
+        if M1_nulling:
+            gropt_params['moment_params'].append([0, 1, 0, -1, -1, -M1[-1,1]+M0[-1,1]*(t[-1]+GRT*1e3), 1.0e-5])
+
+        gropt_params['gfix']  = np.array([g_grad[-1, 1]*1e-3, -99999, 0])
+
+        g_rewind_y, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
+        g_rewind_y = g_rewind_y.T[:,0]*1e3
+
+    elif grad_rew_method == 'ext_trap_area':
+        from pypulseq.make_extended_trapezoid_area import make_extended_trapezoid_area
+
+        if M1_nulling:
+            warnings.warn("M1 nulling is not supported with 'ext_trap_area' method. It will be ignored.")
+            M1_nulling = False
+        # Copy the system to modify slew rate to obey reduced SR of the spirals.
+        system2 = copy.deepcopy(system)
+        system2.max_slew = system.max_slew * slew_ratio
+        _,times_x,amplitudes_x = make_extended_trapezoid_area(channel='x', area=-M0[-1,0]*system2.gamma*1e-6, grad_start=g_grad[-1, 0]*system2.gamma*1e-3, grad_end=0, system=system2)
+        _,times_y,amplitudes_y = make_extended_trapezoid_area(channel='y', area=-M0[-1,1]*system2.gamma*1e-6, grad_start=g_grad[-1, 1]*system2.gamma*1e-3, grad_end=0, system=system2)
+
+        g_rewind_x = 1e3*pts_to_waveform(times_x, amplitudes_x, GRT)/system2.gamma
+        g_rewind_y = 1e3*pts_to_waveform(times_y, amplitudes_y, GRT)/system2.gamma
+
+    elif grad_rew_method == 'exact_time':
+        
+        if M1_nulling:
+            warnings.warn("M1 nulling is not supported with 'exact_time' method. It will be ignored.")
+            M1_nulling = False
+
+        spiral_sys = {
+            'max_slew'          :  max_slew * slew_ratio,   # [T/m/s] 
+            'max_grad'          :  max_grad*0.99,   # [mT/m] 
+            'grad_raster_time'  :  GRT, # [s]
+            }
+
+        [times_x, amplitudes_x] = design_rewinder_exact_time(g_grad[-1, 0], 0, T_rew, -M0[-1,0]*1e-3, spiral_sys)
+        [times_y, amplitudes_y] = design_rewinder_exact_time(g_grad[-1, 1], 0, T_rew, -M0[-1,1]*1e-3, spiral_sys)
+
+        g_rewind_x = pts_to_waveform(times_x, amplitudes_x, GRT)
+        g_rewind_y = pts_to_waveform(times_y, amplitudes_y, GRT)
+
+    elif grad_rew_method == 'm1_nayak':
+        # Krishna rewinder
+        system2 = copy.deepcopy(system)
+        system2.max_slew = system.max_slew * slew_ratio
+        g_grad, g_rewind_x, g_rewind_y = spiral_rewinder_m1_nayak(g_grad, GRT, system2)
+
+    # add zeros to the end of g_rewind_x or g_rewind_y to make them the same length (in case they are not).
+    if len(g_rewind_x) > len(g_rewind_y):
+        g_rewind_y = np.concatenate((g_rewind_y, np.zeros(len(g_rewind_x) - len(g_rewind_y))))
+    else:
+        g_rewind_x = np.concatenate((g_rewind_x, np.zeros(len(g_rewind_y) - len(g_rewind_x))))
+
+    return g_rewind_x, g_rewind_y

--- a/write_rtspiral.py
+++ b/write_rtspiral.py
@@ -3,15 +3,14 @@ import numpy as np
 import matplotlib.pyplot as plt
 from pypulseq import Opts
 from pypulseq import (make_adc, make_sinc_pulse, make_digital_output_pulse, make_delay, 
-                      make_arbitrary_grad, make_trapezoid, make_extended_trapezoid_area, 
+                      make_arbitrary_grad, make_trapezoid, 
                       calc_duration, calc_rf_center, 
                       rotate, add_gradients, make_label)
 from pypulseq.Sequence.sequence import Sequence
 from utils import schedule_FA, load_params
 from utils.traj_utils import save_metadata
-from utils.rewinders import spiral_rewinder_m1_nayak
 from libspiral import vds_fixed_ro, plotgradinfo, raster_to_grad
-from libspiralutils import pts_to_waveform, design_rewinder_exact_time
+from librewinder.design_rewinder import design_rewinder
 from kernels.kernel_handle_preparations import kernel_handle_preparations, kernel_handle_end_preparations
 from math import ceil
 import copy
@@ -68,83 +67,10 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-# === design rewinder ===
-M0 = np.cumsum(g_grad, axis=0) * GRT * 1e3 # [mT.s/m] -> [mT.ms/m]
-t = (np.arange(1, g_grad.shape[0]+1))*GRT*1e3 # [ms]
-tt = (t*np.ones((2, 1))).T
-M1 = np.cumsum(g_grad*tt, axis=0)*GRT*1e3 # [mT.ms^2/m]
-
-if 'M1_nulling' not in params['spiral']:
-    params['spiral']['M1_nulling'] = False
-grad_rew_method = params['spiral']['grad_rew_method']
-T_rew = params['spiral']['rewinder_time']
-# Design rew with gropt
-if grad_rew_method == 'gropt':
-    from gropt import get_min_TE_gfix
-
-    # Method 1: GrOpt, separate optimization
-    gropt_params = {}
-    gropt_params['mode'] = 'free'
-    gropt_params['gmax'] = params['system']['max_grad']*1e-3 # [mT/m] -> [T/m]
-    gropt_params['smax'] = params['system']['max_slew']*params['spiral']['slew_ratio']
-    gropt_params['dt']   = GRT
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M0[-1,0], 1.0e-5]]
-    
-    if params['spiral']['M1_nulling']:
-        gropt_params['moment_params'].append([0, 1, 0, -1, -1, -M1[-1,0]+M0[-1,0]*(t[-1]+GRT*1e3), 1.0e-5])
-
-    gropt_params['gfix']  = np.array([g_grad[-1, 0]*1e-3, -99999, 0])
-
-    g_rewind_x, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_x = g_rewind_x.T[:,0]*1e3
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M0[-1,1], 1.0e-5]]
-
-    if params['spiral']['M1_nulling']:
-        gropt_params['moment_params'].append([0, 1, 0, -1, -1, -M1[-1,1]+M0[-1,1]*(t[-1]+GRT*1e3), 1.0e-5])
-
-    gropt_params['gfix']  = np.array([g_grad[-1, 1]*1e-3, -99999, 0])
-
-    g_rewind_y, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_y = g_rewind_y.T[:,0]*1e3
-
-elif grad_rew_method == 'ext_trap_area':
-    from pypulseq.make_extended_trapezoid_area import make_extended_trapezoid_area
-
-    if params['spiral']['M1_nulling']:
-        warnings.warn("M1 nulling is not supported with 'ext_trap_area' method. It will be ignored.")
-        params['spiral']['M1_nulling'] = False
-    # Copy the system to modify slew rate to obey reduced SR of the spirals.
-    system2 = copy.deepcopy(system)
-    system2.max_slew = system.max_slew*params['spiral']['slew_ratio']
-    _,times_x,amplitudes_x = make_extended_trapezoid_area(channel='x', area=-M0[-1,0]*system2.gamma*1e-6, grad_start=g_grad[-1, 0]*system2.gamma*1e-3, grad_end=0, system=system2)
-    _,times_y,amplitudes_y = make_extended_trapezoid_area(channel='y', area=-M0[-1,1]*system2.gamma*1e-6, grad_start=g_grad[-1, 1]*system2.gamma*1e-3, grad_end=0, system=system2)
-
-    g_rewind_x = 1e3*pts_to_waveform(times_x, amplitudes_x, GRT)/system2.gamma
-    g_rewind_y = 1e3*pts_to_waveform(times_y, amplitudes_y, GRT)/system2.gamma
-
-elif grad_rew_method == 'exact_time':
-    
-    if params['spiral']['M1_nulling']:
-        warnings.warn("M1 nulling is not supported with 'exact_time' method. It will be ignored.")
-        params['spiral']['M1_nulling'] = False
-
-    [times_x, amplitudes_x] = design_rewinder_exact_time(g_grad[-1, 0], 0, T_rew, -M0[-1,0], spiral_sys)
-    [times_y, amplitudes_y] = design_rewinder_exact_time(g_grad[-1, 1], 0, T_rew, -M0[-1,1], spiral_sys)
-
-    g_rewind_x = pts_to_waveform(times_x, amplitudes_x, GRT)
-    g_rewind_y = pts_to_waveform(times_y, amplitudes_y, GRT)
-
-elif grad_rew_method == 'm1_nayak':
-    # Krishna rewinder
-    g_grad, g_rewind_x, g_rewind_y = spiral_rewinder_m1_nayak(g_grad, GRT, system, params['spiral']['slew_ratio'])
-
-# add zeros to the end of g_rewind_x or g_rewind_y to make them the same length (in case they are not).
-if len(g_rewind_x) > len(g_rewind_y):
-    g_rewind_y = np.concatenate((g_rewind_y, np.zeros(len(g_rewind_x) - len(g_rewind_y))))
-else:
-    g_rewind_x = np.concatenate((g_rewind_x, np.zeros(len(g_rewind_y) - len(g_rewind_x))))
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+                                         slew_ratio=params['spiral']['slew_ratio'], \
+                                         grad_rew_method=params['spiral']['grad_rew_method'], \
+                                         M1_nulling=params['spiral']['M1_nulling'])
 
 # concatenate g and g_rewind, and plot.
 g_grad = np.concatenate((g_grad, np.stack([g_rewind_x[0:], g_rewind_y[0:]]).T))

--- a/write_rtspiral.py
+++ b/write_rtspiral.py
@@ -67,7 +67,7 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, params['spiral']['rewinder_time'], system, \
                                          slew_ratio=params['spiral']['slew_ratio'], \
                                          grad_rew_method=params['spiral']['grad_rew_method'], \
                                          M1_nulling=params['spiral']['M1_nulling'])

--- a/write_rtspiral_3d.py
+++ b/write_rtspiral_3d.py
@@ -49,7 +49,7 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, params['spiral']['rewinder_time'], system, \
                                          slew_ratio=params['spiral']['slew_ratio'], \
                                          grad_rew_method=params['spiral']['grad_rew_method'], \
                                          M1_nulling=params['spiral']['M1_nulling'])

--- a/write_rtspiral_3d.py
+++ b/write_rtspiral_3d.py
@@ -8,7 +8,7 @@ from pypulseq import (
 from utils.schedule_FA import schedule_FA
 from utils.load_params import load_params
 from libspiral import vds_fixed_ro, plotgradinfo, raster_to_grad
-from libspiralutils import design_rewinder_exact_time, pts_to_waveform
+from librewinder.design_rewinder import design_rewinder
 from kernels.kernel_handle_preparations import kernel_handle_preparations, kernel_handle_end_preparations
 from math import ceil
 from sigpy.mri.rf import slr 
@@ -49,47 +49,10 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-# === design rewinder ===
-T_rew = 1.2e-3
-M = np.cumsum(g_grad, axis=0) * GRT
-
-grad_rew_method = 1
-# Design rew with gropt
-if grad_rew_method == 1:
-    from gropt.helper_utils import *
-
-    # Method 1: GrOpt, separate optimization
-    gropt_params = {}
-    gropt_params['mode'] = 'free'
-    gropt_params['gmax'] = params['system']['max_grad']*1e-3 # [mT/m] -> [T/m]
-    gropt_params['smax'] = params['system']['max_slew']*params['acquisition']['spiral']['slew_ratio']
-    gropt_params['dt']   = GRT
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,0]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 0]*1e-3, -99999, 0])
-
-    g_rewind_x, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_x = g_rewind_x.T[:,0]*1e3
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,1]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 1]*1e-3, -99999, 0])
-
-    g_rewind_y, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_y = g_rewind_y.T[:,0]*1e3
-
-elif grad_rew_method == 2:
-    [times_x, amplitudes_x] = design_rewinder_exact_time(g_grad[-1, 0], 0, T_rew, -M[-1,0], spiral_sys)
-    [times_y, amplitudes_y] = design_rewinder_exact_time(g_grad[-1, 1], 0, T_rew, -M[-1,1], spiral_sys)
-
-    g_rewind_x = pts_to_waveform(times_x, amplitudes_x, GRT)
-    g_rewind_y = pts_to_waveform(times_y, amplitudes_y, GRT)
-
-# add zeros to the end of g_rewind_x or g_rewind_y to make them the same length (in case they are not).
-if len(g_rewind_x) > len(g_rewind_y):
-    g_rewind_y = np.concatenate((g_rewind_y, np.zeros(len(g_rewind_x) - len(g_rewind_y))))
-else:
-    g_rewind_x = np.concatenate((g_rewind_x, np.zeros(len(g_rewind_y) - len(g_rewind_x))))
-
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+                                         slew_ratio=params['spiral']['slew_ratio'], \
+                                         grad_rew_method=params['spiral']['grad_rew_method'], \
+                                         M1_nulling=params['spiral']['M1_nulling'])
 
 # concatenate g and g_rewind, and plot.
 g_grad = np.concatenate((g_grad, np.stack([g_rewind_x[0:], g_rewind_y[0:]]).T))

--- a/write_rtspiral_cine.py
+++ b/write_rtspiral_cine.py
@@ -63,7 +63,7 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, params['spiral']['rewinder_time'], system, \
                                          slew_ratio=params['spiral']['slew_ratio'], \
                                          grad_rew_method=params['spiral']['grad_rew_method'], \
                                          M1_nulling=params['spiral']['M1_nulling'])

--- a/write_rtspiral_cine.py
+++ b/write_rtspiral_cine.py
@@ -1,15 +1,15 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from pypulseq import Opts
-from pypulseq import (make_adc, make_sinc_pulse, make_digital_output_pulse, make_delay, 
-                      make_arbitrary_grad, make_trapezoid, make_extended_trapezoid_area, 
+from pypulseq import (make_adc, make_sinc_pulse, make_delay, 
+                      make_arbitrary_grad, make_trapezoid, 
                       calc_duration, calc_rf_center, 
                       rotate, add_gradients, make_label)
 from pypulseq.Sequence.sequence import Sequence
 from utils import schedule_FA, load_params
 from utils.traj_utils import save_metadata
 from libspiral import vds_fixed_ro, plotgradinfo, raster_to_grad
-from libspiralutils import pts_to_waveform, design_rewinder_exact_time
+from librewinder.design_rewinder import design_rewinder
 from kernels.kernel_handle_preparations import kernel_handle_preparations, kernel_handle_end_preparations
 from math import ceil
 import copy
@@ -63,59 +63,10 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-# === design rewinder ===
-M = np.cumsum(g_grad, axis=0) * GRT
-
-grad_rew_method = params['spiral']['grad_rew_method']
-T_rew = params['spiral']['rewinder_time']
-# Design rew with gropt
-if grad_rew_method == 'gropt':
-    from gropt import get_min_TE_gfix
-
-    # Method 1: GrOpt, separate optimization
-    gropt_params = {}
-    gropt_params['mode'] = 'free'
-    gropt_params['gmax'] = params['system']['max_grad']*1e-3 # [mT/m] -> [T/m]
-    gropt_params['smax'] = params['system']['max_slew']*params['spiral']['slew_ratio']
-    gropt_params['dt']   = GRT
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,0]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 0]*1e-3, -99999, 0])
-
-    g_rewind_x, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_x = g_rewind_x.T[:,0]*1e3
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,1]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 1]*1e-3, -99999, 0])
-
-    g_rewind_y, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_y = g_rewind_y.T[:,0]*1e3
-
-elif grad_rew_method == 'ext_trap_area':
-    from pypulseq.make_extended_trapezoid_area import make_extended_trapezoid_area
-
-    # Copy the system to modify slew rate to obey reduced SR of the spirals.
-    system2 = copy.deepcopy(system)
-    system2.max_slew = system.max_slew*params['spiral']['slew_ratio']
-    _,times_x,amplitudes_x = make_extended_trapezoid_area(channel='x', area=-M[-1,0]*system2.gamma*1e-3, grad_start=g_grad[-1, 0]*system2.gamma*1e-3, grad_end=0, system=system2)
-    _,times_y,amplitudes_y = make_extended_trapezoid_area(channel='y', area=-M[-1,1]*system2.gamma*1e-3, grad_start=g_grad[-1, 1]*system2.gamma*1e-3, grad_end=0, system=system2)
-
-    g_rewind_x = 1e3*pts_to_waveform(times_x, amplitudes_x, GRT)/system2.gamma
-    g_rewind_y = 1e3*pts_to_waveform(times_y, amplitudes_y, GRT)/system2.gamma
-
-elif grad_rew_method == 'exact_time':
-
-    [times_x, amplitudes_x] = design_rewinder_exact_time(g_grad[-1, 0], 0, T_rew, -M[-1,0], spiral_sys)
-    [times_y, amplitudes_y] = design_rewinder_exact_time(g_grad[-1, 1], 0, T_rew, -M[-1,1], spiral_sys)
-
-    g_rewind_x = pts_to_waveform(times_x, amplitudes_x, GRT)
-    g_rewind_y = pts_to_waveform(times_y, amplitudes_y, GRT)
-
-# add zeros to the end of g_rewind_x or g_rewind_y to make them the same length (in case they are not).
-if len(g_rewind_x) > len(g_rewind_y):
-    g_rewind_y = np.concatenate((g_rewind_y, np.zeros(len(g_rewind_x) - len(g_rewind_y))))
-else:
-    g_rewind_x = np.concatenate((g_rewind_x, np.zeros(len(g_rewind_y) - len(g_rewind_x))))
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+                                         slew_ratio=params['spiral']['slew_ratio'], \
+                                         grad_rew_method=params['spiral']['grad_rew_method'], \
+                                         M1_nulling=params['spiral']['M1_nulling'])
 
 # concatenate g and g_rewind, and plot.
 g_grad = np.concatenate((g_grad, np.stack([g_rewind_x[0:], g_rewind_y[0:]]).T))

--- a/write_rtspiral_multislice.py
+++ b/write_rtspiral_multislice.py
@@ -73,7 +73,7 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
-g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, params['spiral']['rewinder_time'], system, \
                                          slew_ratio=params['spiral']['slew_ratio'], \
                                          grad_rew_method=params['spiral']['grad_rew_method'], \
                                          M1_nulling=params['spiral']['M1_nulling'])

--- a/write_rtspiral_time_optimal.py
+++ b/write_rtspiral_time_optimal.py
@@ -10,7 +10,7 @@ from pypulseq.Sequence.sequence import Sequence
 from utils import schedule_FA, load_params
 from utils.traj_utils import save_metadata
 from libspiral import vds_fixed_ro, plotgradinfo, raster_to_grad
-from libspiralutils import pts_to_waveform, design_rewinder_exact_time
+from librewinder.design_rewinder import design_rewinder
 from kernels.kernel_handle_preparations import kernel_handle_preparations, kernel_handle_end_preparations
 from math import ceil
 import copy
@@ -65,60 +65,10 @@ print(f'Number of interleaves for fully sampled trajectory: {n_int}.')
 t_grad, g_grad = raster_to_grad(g, spiral_sys['adc_dwell'], GRT)
 
 # === design rewinder ===
-M = np.cumsum(g_grad, axis=0) * GRT
-
-grad_rew_method = params['spiral']['grad_rew_method']
-T_rew = params['spiral']['rewinder_time']
-# Design rew with gropt
-if grad_rew_method == 'gropt':
-    from gropt import get_min_TE_gfix
-
-    # Method 1: GrOpt, separate optimization
-    gropt_params = {}
-    gropt_params['mode'] = 'free'
-    gropt_params['gmax'] = params['system']['max_grad']*1e-3 # [mT/m] -> [T/m]
-    gropt_params['smax'] = params['system']['max_slew']*params['spiral']['slew_ratio']
-    gropt_params['dt']   = GRT
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,0]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 0]*1e-3, -99999, 0])
-
-    g_rewind_x, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_x = g_rewind_x.T[:,0]*1e3
-
-    gropt_params['moment_params']  = [[0, 0, 0, -1, -1, -M[-1,1]*1e3, 1.0e-3]]
-    gropt_params['gfix']  = np.array([g_grad[-1, 1]*1e-3, -99999, 0])
-
-    g_rewind_y, T = get_min_TE_gfix(gropt_params, T_rew*1e3, True)
-    g_rewind_y = g_rewind_y.T[:,0]*1e3
-
-elif grad_rew_method == 'ext_trap_area':
-    from pypulseq.make_extended_trapezoid_area import make_extended_trapezoid_area
-
-    # Copy the system to modify slew rate to obey reduced SR of the spirals.
-    system2 = copy.deepcopy(system)
-    system2.max_slew = system.max_slew*params['spiral']['slew_ratio']
-    _,times_x,amplitudes_x = make_extended_trapezoid_area(channel='x', area=-M[-1,0]*system2.gamma*1e-3, grad_start=g_grad[-1, 0]*system2.gamma*1e-3, grad_end=0, system=system2)
-    _,times_y,amplitudes_y = make_extended_trapezoid_area(channel='y', area=-M[-1,1]*system2.gamma*1e-3, grad_start=g_grad[-1, 1]*system2.gamma*1e-3, grad_end=0, system=system2)
-
-    g_rewind_x = 1e3*pts_to_waveform(times_x, amplitudes_x, GRT)/system2.gamma
-    g_rewind_y = 1e3*pts_to_waveform(times_y, amplitudes_y, GRT)/system2.gamma
-
-elif grad_rew_method == 'exact_time':
-
-    [times_x, amplitudes_x] = design_rewinder_exact_time(g_grad[-1, 0], 0, T_rew, -M[-1,0], spiral_sys)
-    [times_y, amplitudes_y] = design_rewinder_exact_time(g_grad[-1, 1], 0, T_rew, -M[-1,1], spiral_sys)
-
-    g_rewind_x = pts_to_waveform(times_x, amplitudes_x, GRT)
-    g_rewind_y = pts_to_waveform(times_y, amplitudes_y, GRT)
-
-# add zeros to the end of g_rewind_x or g_rewind_y to make them the same length (in case they are not).
-if len(g_rewind_x) > len(g_rewind_y):
-    g_rewind_y = np.concatenate((g_rewind_y, np.zeros(len(g_rewind_x) - len(g_rewind_y))))
-else:
-    g_rewind_x = np.concatenate((g_rewind_x, np.zeros(len(g_rewind_y) - len(g_rewind_x))))
-
-len_g_grad = len(g_grad)
+g_rewind_x, g_rewind_y = design_rewinder(g_grad, GRT, params['spiral']['rewinder_time'], system, \
+                                         slew_ratio=params['spiral']['slew_ratio'], \
+                                         grad_rew_method=params['spiral']['grad_rew_method'], \
+                                         M1_nulling=params['spiral']['M1_nulling'])
 
 # concatenate g and g_rewind, and plot.
 g_grad = np.concatenate((g_grad, np.stack([g_rewind_x[0:], g_rewind_y[0:]]).T))


### PR DESCRIPTION
I made changes to how we design rewinders because we use the same rewinder logic in all "write_rtspiral..." functions.

Design_rewinder for spiral trajectories.

```
  Inputs:
      g_grad: array [readout x 2] in units mT/m 
      GRT: gradient raster time (s)
      T_rew: time for rewind (s)
      system: pulseq system object (containing max grad, slew, and other hardware limits)
      slew_ratio: slew ratio to limit spiral rewinder
      grad_rew_method: 'gropt', 'ext_trap_area', 'exact_time', 'm1_nayak'
      M1_nulling: true or false (only available with 'gropt')
  
  Returns:
      g_rewind_x g_rewind_y 
```

This allows us to simple call the `design_rewinder` function in all the write_rtspiral functions instead. 

Tested using all methods:
ext_trap_area:
<img width="199" alt="image" src="https://github.com/user-attachments/assets/87643058-3680-4876-8e98-0f59656f1d1b" />

gropt:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/6b735d1c-b303-4402-8fd5-95a561d8edc3" />

exact_time:
<img width="189" alt="image" src="https://github.com/user-attachments/assets/319fb953-b214-4ce6-9d74-629ea95014e2" />

m1_nayak:
<img width="181" alt="image" src="https://github.com/user-attachments/assets/69578aec-c962-4280-8a5a-afe830191117" />



